### PR TITLE
Update picker.vue

### DIFF
--- a/src/picker.vue
+++ b/src/picker.vue
@@ -55,7 +55,7 @@
 		z-index: 999;
 	}
 	@component wrapper {
-		position: absolute;
+		position: fixed;
 		left: 0;
 		bottom: 0;
 		width: 100%;


### PR DESCRIPTION
如果页面高度超出屏幕，弹出层会滚动。
所以采取 fixed